### PR TITLE
Fix issue with truncated packets.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+mcsauna (1.0.4) precise trusty; urgency=low
+
+  * fix issue with truncated packets introduced by 1.0.3
+
+ -- Daniel Ellis <daniel.ellis@reddit.com>  Wed, 07 Sep 2016 18:13:33 -0700
+
 mcsauna (1.0.3) precise trusty; urgency=low
 
   * add support for multiple commands per packet

--- a/memcached.go
+++ b/memcached.go
@@ -85,9 +85,15 @@ func processSingleKeyWithData(first_line string, remainder []byte) (keys []strin
 		return []string{}, []byte{}, ERR_INVALID_CMD
 	}
 
-	// Return parsed data
+	// Make sure we got a full command
 	// ... bytes + 2 to account for trailing "\r\n"
-	return []string{key}, remainder[bytes+2:], ERR_NONE
+	next_command_idx := bytes + 2
+	if int64(len(remainder)) < next_command_idx {
+		return []string{}, []byte{}, ERR_TRUNCATED
+	}
+
+	// Return parsed data
+	return []string{key}, remainder[next_command_idx:], ERR_NONE
 
 }
 

--- a/memcached_test.go
+++ b/memcached_test.go
@@ -19,12 +19,19 @@ var PARSE_COMMAND_TEST_TABLE = []ParseCommandTest{
 	ParseCommandTest{[]byte("set foo 0 0 3\r\nabc\r\n"), "set", []string{"foo"}, []byte{}, ERR_NONE},
 	ParseCommandTest{[]byte("get bar\r\n"), "get", []string{"bar"}, []byte{}, ERR_NONE},
 	ParseCommandTest{[]byte("\r\n"), "", []string{}, []byte{}, ERR_NO_CMD},
-	ParseCommandTest{[]byte("get foo"), "", []string{}, []byte{}, ERR_TRUNCATED},
 	ParseCommandTest{[]byte("foo bar\r\n"), "", []string{}, []byte{}, ERR_INVALID_CMD},
 	ParseCommandTest{[]byte("get \r\n"), "get", []string{}, []byte{}, ERR_INCOMPLETE_CMD},
 	ParseCommandTest{[]byte("get\r\n"), "", []string{}, []byte{}, ERR_NO_CMD},
 	ParseCommandTest{[]byte("incr foo 1\r\n"), "incr", []string{"foo"}, []byte{}, ERR_NONE},
 	ParseCommandTest{[]byte("decr foo 1\r\n"), "decr", []string{"foo"}, []byte{}, ERR_NONE},
+	// ... test various truncation levels
+	ParseCommandTest{[]byte("get foo"), "", []string{}, []byte{}, ERR_TRUNCATED},
+	ParseCommandTest{[]byte("add foo 2 44 1"), "", []string{}, []byte{}, ERR_TRUNCATED},
+	ParseCommandTest{[]byte("add foo 2 44 1\r"), "", []string{}, []byte{}, ERR_TRUNCATED},
+	ParseCommandTest{[]byte("add foo 2 44 1\r\n"), "add", []string{}, []byte{}, ERR_TRUNCATED},
+	ParseCommandTest{[]byte("add foo 2 44 1\r\n0"), "add", []string{}, []byte{}, ERR_TRUNCATED},
+	ParseCommandTest{[]byte("add foo 2 44 1\r\n0\r"), "add", []string{}, []byte{}, ERR_TRUNCATED},
+	ParseCommandTest{[]byte("add foo 2 44 1\r\n0\r\n"), "add", []string{"foo"}, []byte{}, ERR_NONE},
 
 	// Multiple Commands Per Packet Tests
 	ParseCommandTest{[]byte("get foo\r\nget bar\r\n"), "get", []string{"foo"}, []byte("get bar\r\n"), ERR_NONE},


### PR DESCRIPTION
👓  @spladug @bsimpson63 

Previously, truncated packets were handled just fine, because
we didn't attempt to continue looking for commands in a packet
after we found the initial one.

In 1.0.3, we started reading the byte count for those commands
that also passed a value.  If a full value command and carriage-
return/newline combo were not found, a panic would occur and
mcsauna would crash.  This commit ensures that parsing only
continues for packets with full value commands present.
